### PR TITLE
fix app_asyncprog14_promisefuereinenhttprequest.js

### DIFF
--- a/csa-uebung/13_Async_Prog/app_asyncprog14_promisefuereinenhttprequest.js
+++ b/csa-uebung/13_Async_Prog/app_asyncprog14_promisefuereinenhttprequest.js
@@ -12,8 +12,8 @@ function doRequest(url) {
       let data = '';
       res.on('data', chunk => (data += chunk));
       res.on('end', () => resolve(data));
-      res.on('error', e => reject(e));
     });
+    req.on('error', e => reject(e));
     req.end();
   });
 }


### PR DESCRIPTION
http.request error callback needs to be registered on the request object [documentation reference](https://nodejs.org/api/http.html#httprequesturl-options-callback)